### PR TITLE
Include Rails CSRF protection tokens in m.request data

### DIFF
--- a/app/assets/javascripts/mithril_ujs.js
+++ b/app/assets/javascripts/mithril_ujs.js
@@ -33,7 +33,7 @@
 
   // Rails CSRF protection
 
-  var CSRFparam = '', CSRFtoken = '';
+  var CSRFtoken = '';
 
   var setUpCSRF = function() {
     if ($) {
@@ -51,10 +51,13 @@
     if (CSRFparam && CSRFtoken && !m.requestWithoutCSRFProtection) {
       m.requestWithoutCSRFProtection = m.request;
       m.request = function(options) {
-        var data = options.data || {};
+        var config = options.config;
+
         if (options.method && !/^(GET|HEAD)$/i.test(options.method)) {
-          data[CSRFparam] = CSRFtoken;
-          options.data = data;
+          options.config = function(xhr) {
+            xhr.setRequestHeader('X-CSRF-Token', CSRFtoken);
+            config && config(xhr);
+          };
         }
         m.requestWithoutCSRFProtection(options);
       };


### PR DESCRIPTION
This change automatically includes Rails CSRF tokens in `m.request` data for `POST`, `PUT`, `PATCH`, and `DELETE` requests (`GET` and `HEAD` are specifically excluded; see [the Rails documentation](http://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery)). This is analogous to the behaviour of the [jquery-rails](https://github.com/rails/jquery-rails) gem, which uses `ajaxPrefilter` to inject the `X-CSRF-Token` header.
